### PR TITLE
Add libyear (node)

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,10 @@
         <a href="https://github.com/sbleon/libyear-yarn">libyear-yarn</a>
       </li>
       <li>
+        js (node) -
+        <a href="https://github.com/jdanil/libyear">libyear</a>
+      </li>
+      <li>
         php (composer) -
         <a href="https://github.com/stevedesmond-ca/php-libyear">
           php-libyear


### PR DESCRIPTION
I was after a version of libyear that would work with yarn v2, so I thought it would be worth consolidating all the efforts for each of the node.js package managers, since really only the fetching and parsing of dependencies and their information is different.