### PR TITLE
Add Gradle plugin for libyear (java)

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,6 +70,12 @@
               </a>
             </li>
             <li>
+              java (Gradle) -
+              <a href="https://github.com/f4lco/libyear-gradle-plugin">
+                libyear-gradle-plugin
+              </a>
+            </li>
+            <li>
               your favorite -
               <a href="https://github.com/jaredbeck/libyear.com">
                 contributions welcome


### PR DESCRIPTION
I was a bit surprised that this concept had not been adapted to the Java ecosystem. Hence,  I wrote a plugin for Gradle, a popular build tool. Thank you for creating this website and spreading the word about dependency maintenance.