### PR TITLE
Update .NET and PHP links

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
           <ul>
             <li>
               dotnet (NuGet) -
-              <a href="https://github.com/stevedesmond-ca/dotnet-libyear">
+              <a href="https://github.com/ecoAPM/dotnet-libyear">
                 dotnet-libyear
               </a>
             </li>
@@ -47,7 +47,7 @@
             </li>
             <li>
               php (composer) -
-              <a href="https://github.com/stevedesmond-ca/php-libyear">
+              <a href="https://github.com/ecoAPM/php-libyear">
                 php-libyear
               </a>
             </li>


### PR DESCRIPTION
`dotnet-libyear` and `php-libyear` are now under new ownership, and the repositories have been transferred accordingly -- the old links should redirect in the meantime.