### PR TITLE
Add link to libyear-maven-plugin

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,6 +76,12 @@
               </a>
             </li>
             <li>
+              java (Maven) -
+              <a href="https://github.com/mfoo/libyear-maven-plugin">
+                libyear-maven-plugin
+              </a>
+            </li>
+            <li>
               scala (Maven and SBT) -
               <a href="https://github.com/novomind-ishop/release#show-libyears-of-dependency-updates">
                 release


### PR DESCRIPTION
Hello!

I've just released https://github.com/mfoo/libyear-maven-plugin, the first release of `libyear-maven-plugin` to the central repository. Please could you take a look and see if there's anything I've missed?

Assuming there's no problems, this PR adds libyear-maven-plugin to the list of projects on https://libyear.com. Thanks for maintaining the site!
