### PR TITLE
Add go-libyear to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,12 @@
               </a>
             </li>
             <li>
+              go (modules) -
+              <a href="https://github.com/nieomylnieja/go-libyear">
+                go-libyear
+              </a>
+            </li>
+            <li>
               your favorite -
               <a href="https://github.com/jaredbeck/libyear.com">
                 contributions welcome


### PR DESCRIPTION
It's still a very fresh project I worked on recently, but it's pretty much feature complete and as far as I'm aware there wasn't anything for libyear calculation for Go anywhere on the web.